### PR TITLE
US-4322 Deprecate Last Failed Login At

### DIFF
--- a/lib/authlogic/session/brute_force_protection.rb
+++ b/lib/authlogic/session/brute_force_protection.rb
@@ -53,14 +53,9 @@ module Authlogic
       
       # The methods available for an Authlogic::Session::Base object that make up the brute force protection feature.
       module InstanceMethods
-        # Returns true when the consecutive_failed_logins_limit has been exceeded and is being temporarily banned.
-        # Notice the word temporary, the user will not be permanently banned unless you choose to do so with configuration.
-        # By default they will be banned for 2 hours. During that 2 hour period this method will return true.
+        # Remove brute force protection; lets put this brute force thingy to Cloudflare I guess
         def being_brute_force_protected?
-          exceeded_failed_logins_limit? && (failed_login_ban_for <= 0 ||
-            (attempted_record.respond_to?(:current_login_at) &&
-              attempted_record.current_login_at &&
-              attempted_record.current_login_at >= failed_login_ban_for.seconds.ago))
+          false
         end
         
         private

--- a/lib/authlogic/session/brute_force_protection.rb
+++ b/lib/authlogic/session/brute_force_protection.rb
@@ -58,9 +58,9 @@ module Authlogic
         # By default they will be banned for 2 hours. During that 2 hour period this method will return true.
         def being_brute_force_protected?
           exceeded_failed_logins_limit? && (failed_login_ban_for <= 0 ||
-            (attempted_record.respond_to?(:last_failed_login_at) && 
-              attempted_record.last_failed_login_at &&
-              attempted_record.last_failed_login_at >= failed_login_ban_for.seconds.ago))
+            (attempted_record.respond_to?(:current_login_at) &&
+              attempted_record.current_login_at &&
+              attempted_record.current_login_at >= failed_login_ban_for.seconds.ago))
         end
         
         private

--- a/lib/authlogic/session/magic_columns.rb
+++ b/lib/authlogic/session/magic_columns.rb
@@ -6,7 +6,6 @@ module Authlogic
     #   login_count           Increased every time an explicit login is made. This will *NOT* increase if logging in by a session, cookie, or basic http auth
     #   failed_login_count    This increases for each consecutive failed login. See Authlogic::Session::BruteForceProtection and the consecutive_failed_logins_limit config option for more details.
     #   last_request_at       Updates every time the user logs in, either by explicitly logging in, or logging in by cookie, session, or http auth
-    #   last_failed_login_at  Updates with the current_time when an explicit failed login is made.
     #   current_login_at      Updates with the current time when an explicit login is made.
     #   last_login_at         Updates with the value of current_login_at before it is reset.
     #   current_login_ip      Updates with the request ip when an explicit login is made.
@@ -42,15 +41,9 @@ module Authlogic
       module InstanceMethods
         private
           def increase_failed_login_count
-            if invalid_password?
-              if attempted_record.respond_to?(:failed_login_count)
-                attempted_record.failed_login_count ||= 0
-                attempted_record.failed_login_count += 1
-              end
-              
-              if attempted_record.respond_to?(:last_failed_login_at)
-                attempted_record.last_failed_login_at = klass.default_timezone == :utc ? Time.now.utc : Time.now
-              end
+            if invalid_password? && attempted_record.respond_to?(:failed_login_count)
+              attempted_record.failed_login_count ||= 0
+              attempted_record.failed_login_count += 1
             end
           end
 


### PR DESCRIPTION
This PR intends to remove calls to ```last_failed_login_at```, since that method calls to Redis which need to be migrated / deprecated soon